### PR TITLE
Preserve DAG node natural ordering

### DIFF
--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -1,5 +1,11 @@
 from copy import copy, deepcopy
 
+try:
+    from collections import OrderedDict
+except:
+    from ordereddict import OrderedDict
+
+
 class DAGValidationError(Exception):
     pass
 
@@ -8,8 +14,7 @@ class DAG(object):
 
     def __init__(self):
         """ Construct a new DAG with no nodes or edges. """
-        self.graph = {}
-
+        self.reset_graph()
 
     def add_node(self, node_name, graph=None):
         """ Add a node if it does not exist yet, or error out. """
@@ -140,18 +145,15 @@ class DAG(object):
 
     def reset_graph(self):
         """ Restore the graph to an empty state. """
-        self.graph = {}
+        self.graph = OrderedDict()
 
-
-    def ind_nodes(self, graph):
+    def ind_nodes(self, graph=None):
         """ Returns a list of all nodes in the graph with no dependencies. """
         if graph is None:
-            raise Exception("Graph given is None")
-        all_nodes, dependent_nodes = set(graph.keys()), set()
-        for downstream_nodes in graph.itervalues():
-            [dependent_nodes.add(node) for node in downstream_nodes]
-        return list(all_nodes - dependent_nodes)
+            graph = self.graph
 
+        dependent_nodes = set(node for dependents in graph.itervalues() for node in dependents)
+        return [node for node in graph.keys() if node not in dependent_nodes]
 
     def validate(self, graph=None):
         """ Returns (Boolean, message) of whether DAG is valid. """

--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -9,6 +9,7 @@ except:
 class DAGValidationError(Exception):
     pass
 
+
 class DAG(object):
     """ Directed acyclic graph implementation. """
 
@@ -62,7 +63,6 @@ class DAG(object):
         else:
             raise DAGValidationError()
 
-
     def delete_edge(self, ind_node, dep_node, graph=None):
         """ Delete an edge from the graph. """
         if not graph:
@@ -70,7 +70,6 @@ class DAG(object):
         if dep_node not in graph.get(ind_node, []):
             raise KeyError('this edge does not exist in graph')
         graph[ind_node].remove(dep_node)
-
 
     def rename_edges(self, old_task_name, new_task_name, graph=None):
         """ Change references to a task in existing edges. """
@@ -87,13 +86,11 @@ class DAG(object):
                     edges.remove(old_task_name)
                     edges.add(new_task_name)
 
-
     def predecessors(self, node, graph=None):
         """ Returns a list of all predecessors of the given node """
         if graph is None:
             graph = self.graph
         return [key for key in graph if node in graph[key]]
-
 
     def downstream(self, node, graph=None):
         """ Returns a list of all nodes this node has edges towards. """
@@ -124,7 +121,7 @@ class DAG(object):
     def all_leaves(self, graph=None):
         """ Return a list of all leaves (nodes with no downstreams) """
         if graph is None:
-            graph=self.graph
+            graph = self.graph
         return [key for key in graph if not graph[key]]
 
     def from_dict(self, graph_dict):
@@ -141,7 +138,6 @@ class DAG(object):
                 raise TypeError('dict values must be lists')
             for dep_node in dep_nodes:
                 self.add_edge(ind_node, dep_node)
-
 
     def reset_graph(self):
         """ Restore the graph to an empty state. """
@@ -166,7 +162,6 @@ class DAG(object):
             return (False, 'failed topological sort')
         return (True, 'valid')
 
-
     def _dependencies(self, target_node, graph):
         """ Returns a list of all nodes from incoming edges. """
         if graph is None:
@@ -176,7 +171,6 @@ class DAG(object):
             if target_node in outgoing_nodes:
                 result.add(node)
         return list(result)
-
 
     def topological_sort(self, graph=None):
         """ Returns a topological ordering of the DAG.

--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -192,3 +192,6 @@ class DAG(object):
         if len(l) != len(graph.keys()):
             raise ValueError('graph is not acyclic')
         return l
+
+    def size(self):
+        return len(self.graph)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 from setuptools import setup
+import sys
+install_requires = []
+python_ver = sys.version_info
+if python_ver.major == 2 and python_ver.minor < 7:
+    install_requires = ['ordereddict']
 
 setup(name='py-dag',
       version='2.5.0',
@@ -8,6 +13,7 @@ setup(name='py-dag',
       author_email='travis.thieman@gmail.com',
       license='MIT',
       packages=['dag'],
+      install_requires=install_requires,
       test_suite='nose.collector',
-      tests_require=['nose'],
+      tests_require=['nose'] + install_requires,
       zip_safe=False)

--- a/tests/init_tests.py
+++ b/tests/init_tests.py
@@ -106,3 +106,9 @@ def test_predecessors():
 @with_setup(start_with_graph)
 def test_all_leaves():
     assert dag.all_leaves() == ['d']
+
+@with_setup(start_with_graph)
+def test_size():
+    assert dag.size() == 4
+    dag.delete_node('a')
+    assert dag.size() == 3


### PR DESCRIPTION
- preserve node natural ordering to enable priority queue-like functionality
- change `ind_nodes()` to use the default `self.graph` if graph is not given as parameter
