### PR TITLE
Add convenience capability to initialize a dag directly from a dict. …

### DIFF
--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -16,9 +16,11 @@ class DAGValidationError(Exception):
 class DAG(object):
     """ Directed acyclic graph implementation. """
 
-    def __init__(self):
-        """ Construct a new DAG with no nodes or edges. """
-        self.reset_graph()
+    def __init__(self, graph_dict=None):
+        """ Construct a new DAG with optional graph dict, otherwise with no nodes or edges."""
+        if graph_dict is None:
+            graph_dict = {}
+        self.from_dict(graph_dict)
 
     def add_node(self, node_name, graph=None):
         """ Add a node if it does not exist yet, or error out. """

--- a/tests/init_tests.py
+++ b/tests/init_tests.py
@@ -37,6 +37,18 @@ def test_add_edge():
     assert dag.graph == {'a': set('b'), 'b': set()}
 
 
+def test_from_dict_at_instantiation():
+    temp_dict =   {'a': ['b', 'c'],
+                   'b': ['d'],
+                   'c': ['d'],
+                   'd': []}
+    dag = DAG(temp_dict)
+    assert dag.graph == {'a': set(['b', 'c']),
+                         'b': set('d'),
+                         'c': set('d'),
+                         'd': set()}
+
+
 @with_setup(blank_setup)
 def test_from_dict():
     dag.from_dict({'a': ['b', 'c'],


### PR DESCRIPTION
…Add corresponding test

I saw that add the pull request "add dict default arg to dag constructor #24" was never finished so I went ahead and did what you requested:

1. Modified __init__() to optionally take a dict of dicts to initialize dag
2. Updated the docstring
3. Added a test

I think it should be all ready to accept from what I understand needed to be done.